### PR TITLE
Improve handling of animations / keyframes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,13 @@ module.exports = (context = {}) => async ({
     if (attributes.global) {
       result = await postcss([
         root => {
+          root.walkAtRules(/keyframes$/, atrule => {
+            const name = atrule.params;
+            if (name.indexOf("-global-") !== 0) {
+              atrule.params = "-global-" + name;
+            }
+          });
+
           root.walkRules(async rule => {
             const newSelectors = await parser(selectors => {
               // selectors.each((node) => {
@@ -60,7 +67,8 @@ module.exports = (context = {}) => async ({
                 const selector = container.toString();
 
                 // only override selectors which are not already global
-                if (selector.indexOf(":global") !== 0) {
+                // and don't mess with percentage selectors inside of keyframes
+                if (selector.indexOf(":global") !== 0 && selector.slice(-1) !== "%") {
                   // wrap the first part of the selector in a global pseudo element
                   const firstNode = container.first;
                   container.insertBefore(


### PR DESCRIPTION
**This fixes two things:**

1. **The percentages in keyframes used to get a `:global()` pseudo element around them, which is not right, so now they won't anymore.**
2. **And animation names didn't get globalized like the rest, now they do.**

Or to make it even clearer, let's say I started with the following css in a `<style global>` tag:

```css
div {
    background: red;
    height: 0px;
    animation-name: grow;
    animation-duration: 1s;
}

@keyframes grow {
    0% {
        height: 0px;
    }
    100% {
        height: 500px;
    }
}
```

This preprocessor would add the `:global()` pseudo elements around `div`, but also around `0%` and `100%`. So the following css would then be sent to Svelte.

```css
:global(div) {
    background: red;
    height: 0px;
    animation-name: grow;
    animation-duration: 1s;
}

@keyframes grow {
    :global(0%) {
        height: 0px;
    }
    :global(100%) {
        height: 500px;
    }
}
```

And Svelte would then turn that css into this:

```css
div {
    background: red;
    height: 0px;
    animation-name: svelte-16v9v8t-grow;
    animation-duration: 1s;
}

@keyframes svelte-16v9v8t-grow {
    :global(0%) {
        height: 0px;
    }
    :global(100%) {
        height: 500px;
    }
}
```

As you can see, the 2 things that are wrong here are:

1. The animation name is still scoped by Svelte
2. Svelte didn't remove the `:global()` pseudo elements around `0%` and `100%`, because it didn't expect them to be there in the first place.

My PR fixes both these issues. With my changes, Svelte now receives the following css:

```css
:global(div) {
    background: red;
    height: 0px;
    animation-name: grow;
    animation-duration: 1s;
}

@keyframes -global-grow {
    0% {
        height: 0px;
    }
    100% {
        height: 500px;
    }
}
```

Which Svelte processes and then it ends up like this:

```css
div {
    background: red;
    height: 0px;
    animation-name: grow;
    animation-duration: 1s;
}

@keyframes grow {
    0% {
        height: 0px;
    }
    100% {
        height: 500px;
    }
}
```